### PR TITLE
Update links for source code and issues

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@
             <footer>
                 <ol>
                     <li>Developed by <a href="http://www.codeinchaos.com" target="_blank">Code in Chaos Inc.</a></li>
-                    <li><a href="http://code.google.com/p/rest-console/" target="_blank">Source Code</a> | <a href="http://code.google.com/p/rest-console/issues/list" target="_blank">Issues</a> | <a href="http://www.opensource.org/licenses/mit-license.php" target="_blank">License</a></li>
+                    <li><a href="https://github.com/codeinchaos/rest-console" target="_blank">Source Code</a> | <a href="https://github.com/codeinchaos/rest-console/issues" target="_blank">Issues</a> | <a href="http://www.opensource.org/licenses/mit-license.php" target="_blank">License</a></li>
                 </ol>
             </footer>
         </nav>


### PR DESCRIPTION
This changes the links to point to Github instead of Google Code.
