### PR TITLE
Upgrade to manifest_version 2 for Chrome >= 27.

### DIFF
--- a/application/manifest.json
+++ b/application/manifest.json
@@ -3,10 +3,13 @@
 
     "name": "REST Console",
     "description": "REST Console is an HTTP Request Visualizer and Constructor tool, helps developers build, debug and test RESTful APIs.",
+    "manifest_version": 2,
 
+    "background": {
+        "page": "background.html"
+    },
 
     "options_page": "index.html#options",
-    "background_page": "background.html",
 
     "icons": {
         "16": "images/logo/16.png",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,8 +3,11 @@
 
     "name": "REST Console Launcher",
     "description": "This is a toolbar launcher for REST Console. get the REST Console App at http://www.restconsole.com",
+    "manifest_version": 2,
 
-    "background_page": "background.html",
+    "background": {
+        "page": "background.html"
+    },
 
     "icons": {
         "16": "images/logo/16.png",


### PR DESCRIPTION
# Overview

As of Chrome 27, it is no longer possible to load extensions in Developer mode without `"manifest_version": 2`. And in September, it will no longer be possible for any clients to load the extension at all.

This pull request correctly sets the manifest_version and updates the `background_page` attribute to its new form. With this pull request, the application works as intended with new versions of Chrome.
### Caveats:

Manifest version 2 sets the following script policy (implicit in the manifest):

`"content_security_policy": "script-src 'self'; object-src 'self'"`

This breaks a few of the social links in the app, as well as Google Analytics.
Some users may be passing some confidential data through the app - therefore I have not changed the security policy in this pull request.

If you wish to re-enable these scripts, append the following to `application/manifest.json`:

`"content_security_policy": "script-src 'self' https://apis.google.com http://platform.linkedin.com https://ssl.google-analytics.com; object-src 'self'"`
